### PR TITLE
fix mutation opposite direction

### DIFF
--- a/puzzle8.py
+++ b/puzzle8.py
@@ -119,7 +119,10 @@ class Solver:
 				chromosome[i] = chromosome[i-1].getDifferentAxis()
 			# opposite direction
 			elif(chromosome[i].isOpposite(chromosome[i-1])):
-				chromosome[i] = chromosome[i-1].getDifferent()
+				if(chromosome[i-1].isEqual(chromosome[i-2])):
+					chromosome[i] = chromosome[i].getDifferentAxis()
+				else:
+					chromosome[i] = chromosome[i].getDifferent()
 
 	# <chromosome> applies to the start puzzle.
 	# If one of the directions is exiting Puzzle when applied to Puzzle


### PR DESCRIPTION
Hi dear friend,
If the opposite direction occurs in the loop, it may not be corrected
For example:

[Direction.right, Direction.down, Direction.up]
Because the third element is in the opposite direction of the second element
The direction may not be corrected because the "getDifferent()" function is called on the previous element and the third element may be rebuilt